### PR TITLE
Use HTTPS and trim spaces

### DIFF
--- a/app/src/main/java/uk/co/busydoingnothing/prevo/ArticleActivity.java
+++ b/app/src/main/java/uk/co/busydoingnothing/prevo/ArticleActivity.java
@@ -666,9 +666,9 @@ public class ArticleActivity extends AppCompatActivity
           wordBuilder.append (Character.toLowerCase (ch));
       }
     Uri uri = ((new Uri.Builder ())
-               .scheme ("http")
+               .scheme ("https")
                .encodedPath ("//vortaro.net/")
-               .fragment (wordBuilder.toString ())).build ();
+               .fragment (wordBuilder.toString ().trim ())).build ();
     Intent intent = new Intent (Intent.ACTION_VIEW, uri);
 
     try


### PR DESCRIPTION
When I press the PIV button at the word "metiejo", I am sent to this broken URL: https://vortaro.net/#metiejo%20_kd
Trimming spaces from the word should fix this issue.

I've also changed "http" to "https", as vortaro.net now supports that.